### PR TITLE
Increase body-parser limit to prevent 413 Payload Too Large errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^2.0.0",
-    "node-sass": "^7.0.1",
-    "sass": "^1.32.0",
+    "sass": "^1.87.0",
     "vite": "^2.7.2",
     "vite-plugin-pwa": "^0.12.8"
   }

--- a/server.js
+++ b/server.js
@@ -14,8 +14,8 @@ const port = process.env.APP_PORT || 8080;
 const chalk = require('chalk');
 const { version } = require("./package.json");
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json({ limit: '50mb' }));
+app.use(bodyParser.urlencoded({ extended: true, limit: '50mb' }));
 
 class Server {
     dataObject = null;


### PR DESCRIPTION
This PR increases the request size limits for `body-parser` in `server.js` to resolve an issue where large payloads sent from the X4 mod were resulting in HTTP 413 (Payload Too Large) errors.

Specifically:
- Set `bodyParser.json({ limit: '50mb' })` and `bodyParser.urlencoded({ extended: true, limit: '50mb' })` to support large data transfers.
- Also includes an update to `package.json` to change the `sass` dependency from `node-sass` to `sass` for better compatibility with modern environments.

These changes ensure the server can properly handle large data objects (such as full sector dumps or large save snapshots) without failing.